### PR TITLE
Remove current_device from ModelPatcher init call to work with most recent ComfyUI

### DIFF
--- a/nodes/load_flatten_model_node.py
+++ b/nodes/load_flatten_model_node.py
@@ -99,7 +99,7 @@ class FlattenCheckpointLoaderNode:
         load_device = comfy.model_management.get_torch_device()
         offload_device = comfy.model_management.unet_offload_device()
         model_patcher = comfy.model_patcher.ModelPatcher(
-            model.model, load_device=load_device, offload_device=offload_device, current_device=offload_device)
+            model.model, load_device=load_device, offload_device=offload_device)
 
         out = list(out)
         out[0] = model_patcher


### PR DESCRIPTION
ComfyUI had a change today that removed current_device from the ModelPatcher __init__ function. This PR removes removes it so that the code can still run without throwing an exception.

Previous ComfyUI versions defaulted this value to be the offload device, so the change is backwards compatible with old ComfyUI versions as well.